### PR TITLE
killercoda: change urls to point to main repo

### DIFF
--- a/killercoda/install.sh
+++ b/killercoda/install.sh
@@ -38,8 +38,7 @@ function sock-shop() {
 function sock-shop-ingress() {
   echo "Configuring ingress for socks-shop demo application..."
 
-  # TODO: Change fork URL.
-  kubectl apply -f "https://raw.githubusercontent.com/roobre/xk6-disruptor-demo/main/killercoda/manifests/front-end-ingress-traefik.yaml" &>/dev/null \
+  kubectl apply -f "https://raw.githubusercontent.com/grafana/xk6-disruptor-demo/main/killercoda/manifests/front-end-ingress-traefik.yaml" &>/dev/null \
     || error "creating traefik ingress"
 
   echo "Ingress configured."

--- a/killercoda/intro/foreground.sh
+++ b/killercoda/intro/foreground.sh
@@ -1,5 +1,5 @@
 # Hold tight while we fetch our installer script.
-curl -sSLO "https://raw.githubusercontent.com/roobre/xk6-disruptor-demo/main/killercoda/install.sh" && chmod +x install.sh
+curl -sSLO "https://raw.githubusercontent.com/grafana/xk6-disruptor-demo/main/killercoda/install.sh" && chmod +x install.sh
 #
 # We'll now install the xk6-disruptor binary for you.
 #


### PR DESCRIPTION
URLs introduced in #9 pointed to my fork as they needed to be testable. After said PR has been merged, we need to update the URLs to point to the main repo.
- [x] Update URLs
- [ ] Check if it is possible to create an org-wide account on killercoda