### PR TITLE
killercoda: symlink kubeconfig instead of exporting env var

### DIFF
--- a/killercoda/install.sh
+++ b/killercoda/install.sh
@@ -21,6 +21,10 @@ function xk6-disruptor() {
   mv "$XK6_DISRUPTOR_INSTALL_PATH/xk6-disruptor-linux-amd64" "$XK6_DISRUPTOR_INSTALL_PATH/xk6-disruptor"
 
   echo "xk6-disruptor $XK6_DISRUPTOR_VERSION installed to $XK6_DISRUPTOR_INSTALL_PATH"
+
+  echo "Symlinking k3s kubeconfig to default path"
+  mkdir -p ~/.kube
+  ln -s /etc/rancher/k3s/k3s.yaml ~/.kube/config
 }
 
 function sock-shop() {

--- a/killercoda/install.sh
+++ b/killercoda/install.sh
@@ -22,9 +22,11 @@ function xk6-disruptor() {
 
   echo "xk6-disruptor $XK6_DISRUPTOR_VERSION installed to $XK6_DISRUPTOR_INSTALL_PATH"
 
-  echo "Symlinking k3s kubeconfig to default path"
-  mkdir -p ~/.kube
-  ln -s /etc/rancher/k3s/k3s.yaml ~/.kube/config
+  if [ ! -e ~/.kube/config ]; then
+    echo "Symlinking k3s kubeconfig to default path"
+    mkdir -p ~/.kube
+    ln -s /etc/rancher/k3s/k3s.yaml ~/.kube/config
+  fi
 }
 
 function sock-shop() {

--- a/killercoda/intro/foreground.sh
+++ b/killercoda/intro/foreground.sh
@@ -13,10 +13,6 @@ curl -sSLO "https://raw.githubusercontent.com/grafana/xk6-disruptor-demo/main/ki
 #
 ./install.sh sock-shop-ingress
 #
-# Finally, we'll export the path for the kubeconfig file
-#
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-#
 # ===================================================================================
 # Everything is set! Kubernetes is working hard to get the demo application ready.
 # This can take several minutes. Hold tight. 


### PR DESCRIPTION
The current approach exporting `KUBECONFIG` during the installation flow works well for the first open tab, but it does not get propagated if the user creates new tabs:

![image](https://github.com/grafana/xk6-disruptor-demo/assets/969721/66d01dc7-c7c4-4ad5-8fde-aba224d80305)

If the user tries to run xk6 on these tabs, it will fail with:

```
ERRO[0000] GoError: error creating Kubernetes helper: stat /root/.kube/config: no such file or directory
```

The symlimnk approach should be more universal.

An (untested) alternative approach could be to echo the variable export to `.bashrc`, but I believe that can be more intrusive or unexpected than symlinking the config to the standard path.

Thanks @ppcano for spotting this!

---

This is a copy of #13 which I somehow managed to accidentally merge. The spurious merge is now reverted.